### PR TITLE
Replace jsdom with Cheerio

### DIFF
--- a/docs/usage/testing.md
+++ b/docs/usage/testing.md
@@ -33,20 +33,21 @@ describe('Foo bar', function() {
         helper.render('template', {
             foo: 'bar',
             lorem: 'ipsum'
-        }, function(error, dom, output) {
-            var $ = dom.$;
+        }, function(error, $, output) {
             assert.strictEqual($('[data-test="fooitem"]').length, 1);
             done();
         });
     });
 ```
 
+In the `helper.render` callback, the `$` parameter is a [Cheerio](https://github.com/cheeriojs/cheerio) instance which allows you to use jQuery-like functions to access the render output. The `output` parameter contains the full output as a string.
+
 When testing templates that are in subfolders, be sure to pass in any subfolders in the same way that you'd include a partial
 
 ```js
 helper.render('mysubfolder___templatename', {
     foo: 'bar'
-}, function(error, dom, output) {
+}, function(error, $, output) {
     // etc etc
 });
 ```

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 	"dependencies": {
 		"async": "~1.4",
 		"body-parser": "~1.13",
+		"cheerio": "~0.19",
 		"connect": "~3.4",
 		"cookie-parser": "~1.3",
 		"csswring": "~3.0",
@@ -75,7 +76,6 @@
 	"devDependencies": {
 		"istanbul": "~0.3",
 		"jscs": "^2",
-		"jsdom": "~3.1",
 		"jshint": "^2",
 		"mocha": "^2",
 		"mockery": "~1.4",

--- a/tests/helpers/template.js
+++ b/tests/helpers/template.js
@@ -5,12 +5,11 @@ process.env.TZ = 'UTC';
 module.exports = function(env) {
 	var fs = require('fs');
 	var path = require('path');
-	var jsdom = require('jsdom');
+	var cheerio = require('cheerio');
 	var sinon = require('sinon');
 	var config = require('../../lib/config')(env || 'development', null, {});
 	var renderer = null;
 	var assetPath = null;
-	var $ = fs.readFileSync(path.join(__dirname, '..', 'client', 'lib', 'jquery-1.9.1.js')).toString();
 
 	return {
 		getDust: function() {
@@ -83,13 +82,9 @@ module.exports = function(env) {
 					}
 					_callback(err, null, null);
 				} else {
-					jsdom.env({
-						html: raw,
-						src: [$],
-						done: function(err, dom) {
-							_callback(err, dom, raw);
-						}
-					});
+					var $ = cheerio.load(raw);
+					$.$ = $; // Compatibility change. Will deprecate
+					_callback(null, $, raw);
 				}
 			});
 			// jscs:enable disallowDanglingUnderscores

--- a/tests/server/templates/namespace.js
+++ b/tests/server/templates/namespace.js
@@ -26,7 +26,7 @@ describe('Template overriding', function() {
 				namespace: 'tests'
 			}
 		};
-		helper.render('namespace', json, function(err, dom) {
+		helper.render('namespace', json, function(err, $) {
 			assert.isNull(err);
 
 			var expected = [
@@ -48,7 +48,6 @@ describe('Template overriding', function() {
 				}
 			];
 
-			var $ = dom.$;
 			$('[data-test="templates"]').children('dd').each(function(i, item) {
 				assert.strictEqual(expected[i].path, $(item).text(), 'Loading template ' + expected[i].template);
 			});
@@ -62,7 +61,7 @@ describe('Template overriding', function() {
 				namespace: 'tests__a'
 			}
 		};
-		helper.render('namespace', json, function(err, dom) {
+		helper.render('namespace', json, function(err, $) {
 			assert.isNull(err);
 
 			var expected = [
@@ -84,7 +83,6 @@ describe('Template overriding', function() {
 				}
 			];
 
-			var $ = dom.$;
 			$('[data-test="templates"]').children('dd').each(function(i, item) {
 				assert.strictEqual(expected[i].path, $(item).text(), 'Loading template ' + expected[i].template);
 			});
@@ -98,7 +96,7 @@ describe('Template overriding', function() {
 				namespace: 'tests__b'
 			}
 		};
-		helper.render('namespace', json, function(err, dom) {
+		helper.render('namespace', json, function(err, $) {
 			assert.isNull(err);
 
 			var expected = [
@@ -120,7 +118,6 @@ describe('Template overriding', function() {
 				}
 			];
 
-			var $ = dom.$;
 			$('[data-test="templates"]').children('dd').each(function(i, item) {
 				assert.strictEqual(expected[i].path, $(item).text(), 'Loading template ' + expected[i].template);
 			});
@@ -134,7 +131,7 @@ describe('Template overriding', function() {
 				namespace: 'tests__a__b'
 			}
 		};
-		helper.render('namespace', json, function(err, dom) {
+		helper.render('namespace', json, function(err, $) {
 			assert.isNull(err);
 
 			var expected = [
@@ -156,7 +153,6 @@ describe('Template overriding', function() {
 				}
 			];
 
-			var $ = dom.$;
 			$('[data-test="templates"]').children('dd').each(function(i, item) {
 				assert.strictEqual(expected[i].path, $(item).text(), 'Loading template ' + expected[i].template);
 			});


### PR DESCRIPTION
I'm experimenting with replacing jsdom with Cheerio, to see if we can get Node.js 4.x support. Unfortunately this is a breaking change in most cases; I'll see if I can limit the damage or mock out a simple DOM API which works for existing tests.

We don't have to go with Cheerio, just wanted to try things out. Otherwise we may not be able to support the latest Node for some time :(