### PR TITLE
Add support for Node.js 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,26 @@
 
-# Run tests in Node.js 0.10 and 0.12
+# Build matrix
 language: node_js
-node_js:
-  - "0.10"
-  - "0.12"
+matrix:
+  include:
 
-# Build only master and shunter-npm (plus pull-requests)
+    # Lint only in Node.js 0.10
+    - node_js: '0.10'
+      env: LINT=true
+
+    # Run tests in Node.js 0.10
+    - node_js: '0.10'
+
+    # Run tests in Node.js 0.12
+    - node_js: '0.12'
+
+# Restrict builds on branches
 branches:
   only:
     - master
     - /^\d+\.\d+\.\d+$/
 
-# Environment variables for the build
-env:
-  matrix:
-    - "LINT=true"
-    - "TEST=true"
-
 # Build script
 script:
   - 'if [ $LINT ]; then make lint; fi'
-  - 'if [ $TEST ]; then make lcov-levels; fi'
+  - 'if [ ! $LINT ]; then make lcov-levels; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,25 @@ matrix:
     # Run tests in Node.js 0.12
     - node_js: '0.12'
 
+    # Run tests in Node.js 4.x (dependencies require GCC 4.8)
+    - node_js: '4'
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.8
+            - g++-4.8
+
 # Restrict builds on branches
 branches:
   only:
     - master
     - /^\d+\.\d+\.\d+$/
+
+# Use GCC 4.8 if it's available
+before_install:
+  - 'if [ ! `which gcc-4.8` == "" ]; then export CXX=g++-4.8 && export CC=gcc-4.8; fi'
 
 # Build script
 script:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Shunter works by proxying user requests through to a back-end which responds wit
 Requirements
 ------------
 
-Shunter requires [Node.js][node] 0.10 - 0.12, which should come with [npm][npm]. This should be easy to get running on Mac and Linux.
+Shunter requires [Node.js][node] 0.10–4.x, which should come with [npm][npm]. This should be easy to get running on Mac and Linux.
 
 On Windows things are a bit more complicated due to the Shunter install process requiring a C compiler. Here are some useful links to help you:
 
@@ -72,6 +72,6 @@ Copyright &copy; 2015, Nature Publishing Group
 [info-build]: https://travis-ci.org/nature/shunter
 [shield-dependencies]: https://img.shields.io/gemnasium/nature/shunter.svg
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
-[shield-node]: https://img.shields.io/badge/node.js%20support-0.10–0.12-yellow.svg
+[shield-node]: https://img.shields.io/badge/node.js%20support-0.10–4-brightgreen.svg
 [shield-npm]: https://img.shields.io/npm/v/shunter.svg
 [shield-build]: https://img.shields.io/travis/nature/shunter/master.svg

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 Getting Started with Shunter
 ============================
 
-Before we begin, you'll need to have [Node.js](https://nodejs.org/) installed, Shunter requires Node.js 0.10 - 0.12. The getting started guide will teach you how to put together a basic application with Shunter. [API Documentation](usage/index.md) is also available if you need more detail.
+Before we begin, you'll need to have [Node.js](https://nodejs.org/) installed, Shunter requires Node.js 0.10–4.x. The getting started guide will teach you how to put together a basic application with Shunter. [API Documentation](usage/index.md) is also available if you need more detail.
 
 This guide will not explain every feature of Shunter. Its aim is to get you up-and-running in as little time as possible.
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	"bugs": "https://github.com/nature/shunter/issues",
 
 	"engines": {
-		"node": ">=0.10 <=0.12"
+		"node": ">=0.10 <=4"
 	},
 	"dependencies": {
 		"async": "~1.4",


### PR DESCRIPTION
There's a passing Travis build here: https://travis-ci.org/nature/shunter/builds/82315441

It turns out the node-gyp issue was actually because Travis runs `gcc 4.6` whereas building modules against Node.js 4's version of V8 requires `gcc 4.8`. We're now installing a more up-to-date `gcc` during the Travis run for Node.js 4.

I've also overhauled the Travis config so that the linter only runs on one version of Node.js. This should speed up build times a little. We're linting in Node.js 0.10 for now, I thought it might be best to lint with the lowest supported version to be sure that it works.