### PR TITLE
Removes the rem fallback support

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -77,11 +77,6 @@ var compile = function(data, callback) {
 			return deleteAsset(name);
 		}
 
-		// Handle fallback from rem to px
-		content = content.replace(/font(?:-size)?:[^;}]*?([0-9.]+)rem/g, function(all, val) {
-			return 'font-size:' + (parseFloat(val) * 10) + 'px;' + all;
-		});
-
 		return {
 			path: config.path.publicResources + '/' + data.assets[name],
 			content: content

--- a/docs/usage/resources.md
+++ b/docs/usage/resources.md
@@ -143,7 +143,6 @@ Production Differences
 Shunter provides a build script that will do the following things for a production environemt:
 
 * Concatenate and minify CSS and JavaScript
-* Provide font size fallbacks for Internet Explorer 7 and 8 (convert `rem` units to `px`)
 * Write static files to `public/resources` with MD5-fingerprinted file names for cache invalidation
 * Create a `manifest.json` file that maps the logical names for resources to their actual fingerprinted file names
 


### PR DESCRIPTION
This is being removed from shunter as its better placed within an ejs
helper.