### PR TITLE
Add the ability to load per app mincer extensions

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -110,7 +110,8 @@ module.exports = function(env, config, args) {
 			filtersInput: 'input',
 			filtersOutput: 'output',
 			dust: 'dust',
-			ejs: 'ejs'
+			ejs: 'ejs',
+			mincer: 'mincer'
 		},
 		log: new winston.Logger({
 			transports: [

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -51,26 +51,39 @@ module.exports = function(config) {
 			}
 		});
 	});
+
+	var initExtensions = function() {
+		var paths = [].slice.call(arguments, 0, -1);
+		var callback = arguments[arguments.length - 1];
+		var locations = [config.path.shunterRoot].concat(modulesPaths, hostAppDir);
+
+		if (typeof callback === 'function') {
+			locations.forEach(function(dir) {
+				var extensionPath = path.join.apply(path, [dir].concat(paths));
+				eachModule(extensionPath, callback);
+			});
+		}
+	};
+
 	// load input filters from host app and modules
-	var allFilters = [config.path.shunterRoot].concat(modulesPaths, hostAppDir);
-	allFilters.forEach(function(dir) {
-		var inputFilterPath = path.join(dir, config.structure.filters, config.structure.filtersInput);
-		eachModule(inputFilterPath, function(name, mod) {
-			if (typeof mod === 'function') {
-				inputFilters.add(mod);
-			}
-		});
+	initExtensions(config.structure.filters, config.structure.filtersInput, function(name, inputFilter) {
+		if (typeof inputFilter === 'function') {
+			inputFilters.add(inputFilter);
+		}
 	});
 
 	// load ejs helpers from the host app and modules
-	var allHelpers = [config.path.shunterRoot].concat(modulesPaths, hostAppDir);
-	allHelpers.forEach(function(dir) {
-		var ejsHelperPath = path.join(dir, config.structure.ejs);
-		eachModule(ejsHelperPath, function(name, mod, file) {
-			if (typeof mod === 'function') {
-				require(file)(environment, manifest, config);
-			}
-		});
+	initExtensions(config.structure.ejs, function(name, initEjsHelper) {
+		if (typeof initEjsHelper === 'function') {
+			initEjsHelper(environment, manifest, config);
+		}
+	});
+
+	// load mincer extensions from the host app and modules
+	initExtensions(config.structure.mincer, function(name, initMincerExtension) {
+		if (typeof initMincerExtension === 'function') {
+			initMincerExtension(mincer, config);
+		}
 	});
 
 	return {
@@ -87,12 +100,11 @@ module.exports = function(config) {
 
 		initDustExtensions: function() {
 			require('./dust')(dust, this, config);
-			modulesPaths.concat([config.path.shunterRoot, hostAppDir]).forEach(function(dir) {
-				var moduleDustPath = path.join(dir, config.structure.dust);
-				eachModule(moduleDustPath, function(name, initDustExtension) {
+			initExtensions(config.structure.dust, function(name, initDustExtension) {
+				if (typeof initDustExtension === 'function') {
 					initDustExtension(dust, this, config);
-				});
-			});
+				}
+			}.bind(this));
 		},
 
 		compileFile: function(fp) {


### PR DESCRIPTION
De-duplicate and clean up how we load extensions/helpers in renderer

This changes the order dust helpers are searched for to match the order used when checking for other extensions (e.g. ejs, or input filters)

Previously we'd check for dust helpers in shunter extension modules paths before shunter itself - now shunter is checked first allowing these extensions to override the core behaviour.

Addresses #59
