### PR TITLE
Remove erroneous next() call from res.end handler

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -99,7 +99,6 @@ module.exports = function(config, renderer) {
 				} else {
 					dispatch.send(json.error, '', req, res);
 				}
-				next();
 			};
 
 			res.__originalWriteHead = res.writeHead;


### PR DESCRIPTION
This was causing an error with headers being sent twice if you used async helpers in dust. To be honest I'm not entirely sure how they would be related, but this next() call definitely doesn't look right...