### PR TITLE
Use the name option in JServe

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -50,6 +50,7 @@ var app = jserve({
 		addLatency,
 		serveRemoteJson
 	],
+	name: 'Shunter Serve',
 	path: args.data,
 	port: args.port,
 	templatesPath: __dirname + '/../view/jserve'


### PR DESCRIPTION
Now JServe won't appear in the logs, instead it will read:

> Shunter Serve started on http://localhost...