### PR TITLE
Fix to make sure named routes aren't matched against the URL

### DIFF
--- a/docs/migration/3.0.md
+++ b/docs/migration/3.0.md
@@ -1,0 +1,34 @@
+
+Shunter Migration Guide, 2.0 to 3.0
+===================================
+
+This guide outlines how to migrate from Shunter 2.x to Shunter 3.x. It outlines breaking changes which might cause issues when you upgrade.
+
+Route Matching
+--------------
+
+If you were defining routes as regex to be matched against the url in your `routes.json`, as follows:
+
+```js
+{
+	"localhost": {
+		"^\\/path": {
+			"host": "127.0.0.1",
+			"port": 1337
+		}
+	}
+}
+```
+
+The regex will now need to be delimited with `/` characters, like this:
+
+```js
+{
+	"localhost": {
+		"/^\\/path/": {
+			"host": "127.0.0.1",
+			"port": 1337
+		}
+	}
+}
+```

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -5,3 +5,4 @@ Migration Guide
 Shunter's API changes between major versions. This is a guide to help you make the switch when this happens.
 
 - [Migrating from 1.0 to 2.0](2.0.md)
+- [Migrating from 2.0 to 3.0](3.0.md)

--- a/docs/usage/configuration-reference.md
+++ b/docs/usage/configuration-reference.md
@@ -185,7 +185,7 @@ You may like to modify this config object to reflect the environments to which y
 Adding Custom Configurations
 ----------------------------
 
-The items above are the default configurations which may be over-ridden. You will probably need to define some configuration that is unique to your own Shunter application. These can be neatly organized as JSON files in a config directory and required by your Shunter application at start-up to either append or overwrite existing configs. In the example below the `routes.json` usually required by Shunter has been palced in a `route.json` file in the config directory and required from that location:
+The items above are the default configurations which may be over-ridden. You will probably need to define some configuration that is unique to your own Shunter application. These can be neatly organized as JSON files in a config directory and required by your Shunter application at start-up to either append or overwrite existing configs. In the example below the `routes.json` usually required by Shunter has been placed in a `routes.json` file in the config directory and required from that location:
 
 ```js
 var app = shunter({

--- a/lib/router.js
+++ b/lib/router.js
@@ -18,6 +18,13 @@ module.exports = function(config) {
 		}
 	}
 
+	var matchRoute = function(pattern, url) {
+		if (pattern.match(/^\/.+?\/$/)) {
+			return url.match(new RegExp(pattern.replace(/^\//, '').replace(/\/$/, ''), 'i'));
+		}
+		return false;
+	};
+
 	return {
 		map: function(domain, url) {
 			domain = domain.replace(/:[0-9]+$/, '');
@@ -29,7 +36,7 @@ module.exports = function(config) {
 			}
 			for (var pattern in routes[domain]) {
 				if (pattern !== defaultRoute && routes[domain].hasOwnProperty(pattern)) {
-					if (url.match(new RegExp(pattern, 'i'))) {
+					if (matchRoute(pattern, url)) {
 						return routes[domain][pattern];
 					}
 				}

--- a/tests/server/core/router.js
+++ b/tests/server/core/router.js
@@ -10,15 +10,15 @@ describe('Proxy routing', function() {
 		config = {};
 		config.routes = {
 			localhost: {
-				'\/test\/.*': {
+				'/\\/test\\/.*/': {
 					host: 'test-www.nature.com',
 					port: 80
 				},
-				'\/test\/foo': {
+				'/\\/test\\/foo/': {
 					host: 'test-www.nature.com',
 					port: 81
 				},
-				'\/foo\/bar': {
+				'/\\/foo\\/bar/': {
 					host: 'staging-www.nature.com',
 					port: 82
 				},
@@ -45,7 +45,7 @@ describe('Proxy routing', function() {
 	it('Should create a routes object from config objects\'s contents', function() {
 		config.routes = {
 			localhost: {
-				foo: 'bar'
+				'/foo/': 'bar'
 			}
 		};
 		var router = require(moduleName)(config);
@@ -56,10 +56,10 @@ describe('Proxy routing', function() {
 	it('Should get the route from the given host if possible', function() {
 		config.routes = {
 			'www.nature.com': {
-				foo: 'success'
+				'/foo/': 'success'
 			},
 			localhost: {
-				foo: 'fail'
+				'/foo/': 'fail'
 			}
 		};
 		var router = require(moduleName)(config);
@@ -70,10 +70,10 @@ describe('Proxy routing', function() {
 	it('Should ignore the port 80', function() {
 		config.routes = {
 			'www.nature.com': {
-				foo: 'success'
+				'/foo/': 'success'
 			},
 			localhost: {
-				foo: 'fail'
+				'/foo/': 'fail'
 			}
 		};
 		var router = require(moduleName)(config);
@@ -84,10 +84,10 @@ describe('Proxy routing', function() {
 	it('Should fallback to localhost if the host doesn\'t match', function() {
 		config.routes = {
 			'www.nature.com': {
-				foo: 'fail'
+				'/foo/': 'fail'
 			},
 			localhost: {
-				foo: 'success'
+				'/foo/': 'success'
 			}
 		};
 		var router = require(moduleName)(config);
@@ -98,7 +98,7 @@ describe('Proxy routing', function() {
 	it('Should return null if the host doesn\'t match and no localhost routes are defined', function() {
 		config.routes = {
 			'www.nature.com': {
-				foo: 'fail'
+				'/foo/': 'fail'
 			}
 		};
 		var router = require(moduleName)(config);
@@ -140,5 +140,9 @@ describe('Proxy routing', function() {
 		assert.equal(route.port, 9000);
 	});
 
-
+	it('Should not match a named route against the url', function() {
+		var route = require(moduleName)(config).map('localhost', '/capybara');
+		assert.equal(route.host, '127.0.0.1');
+		assert.equal(route.port, 5410);
+	});
 });


### PR DESCRIPTION
Should resolve #71 requires that patterns intended to be matched against the url are delimited with / characters.