### PR TITLE
Add the ability to mount additional middleware

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -36,6 +36,7 @@ API Documentation
   - [Custom Configurations](configuration-reference.md#adding-custom-configurations)
   - [Configuring Modules](configuration-reference.md#configuring-modules)
   - [Command Line Options](configuration-reference.md#command-line-options)
+- [Middleware](middleware.md)
 - [Routing](routing.md)
   - [Examples](routing.md#examples)
   - [Route Config Options](routing.md#route-config-options)

--- a/docs/usage/middleware.md
+++ b/docs/usage/middleware.md
@@ -1,0 +1,25 @@
+
+Middleware
+==========
+
+Shunter uses [Connect](https://github.com/senchalabs/connect) under the hood and exposes Connect's `use` method to allow you to add your own middleware to the stack. The middleware that you specify gets mounted before Shunter's proxying behaviour so you're able to hijack certain routes.
+
+Shunter middleware works in the same way as Connect:
+
+```js
+var app = shunter({});
+
+// Mount middleware on all routes
+app.use(function(request, response, next) {
+    // ...
+});
+
+// Mount middleware on the /foo route
+app.use('/foo', function(request, response, next) {
+    // ...
+});
+
+app.start();
+```
+
+This allows you to expose information about Shunter's environment, or add in routes that you don't wish to hit one of the back end applications that your application proxies to.

--- a/lib/config.js
+++ b/lib/config.js
@@ -78,6 +78,7 @@ module.exports = function(env, config, args) {
 
 	var defaultConfig = {
 		argv: args,
+		middleware: [],
 		modules: [],
 		path: {
 			root: appRoot,

--- a/lib/server.js
+++ b/lib/server.js
@@ -81,6 +81,9 @@ module.exports = function(config) {
 	};
 
 	return {
+		use: function() {
+			config.middleware.push(Array.prototype.slice.call(arguments));
+		},
 		start: function() {
 			if (cluster.isMaster) {
 				saveTimestamp();

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -35,6 +35,10 @@ module.exports = function(config) {
 		app.use(config.web.resources, renderer.assetServer());
 	}
 
+	config.middleware.forEach(function(args) {
+		app.use.apply(app, args);
+	});
+
 	app.use('/ping', processor.ping);
 	app.use('/template', bodyParser.json({limit: config.argv['max-post-size']}));
 	app.use('/template', processor.api);

--- a/tests/server/core/server.js
+++ b/tests/server/core/server.js
@@ -18,6 +18,7 @@ describe('Clustering', function() {
 				root: '/'
 			},
 			log: require('../mocks/log'),
+			middleware: [],
 			argv: {
 				'max-child-processes': 5
 			}
@@ -260,6 +261,25 @@ describe('Clustering', function() {
 			server.start();
 			assert.isTrue(worker.calledOnce);
 			assert.equal(worker.args[0][0].path.root, '/');
+		});
+	});
+
+	describe('Middleware', function() {
+		it('Should expose a `use` method', function() {
+			assert.isFunction(server.use);
+		});
+
+		it('Should add the arguments passed into `use` to the middleware config', function() {
+			var fn1 = function() {};
+			var fn2 = function() {};
+			server.use('foo', fn1);
+			server.use(fn2);
+			assert.lengthEquals(config.middleware, 2);
+			assert.isArray(config.middleware[0]);
+			assert.strictEqual(config.middleware[0][0], 'foo');
+			assert.strictEqual(config.middleware[0][1], fn1);
+			assert.isArray(config.middleware[1]);
+			assert.strictEqual(config.middleware[1][0], fn2);
 		});
 	});
 });

--- a/tests/server/core/worker.js
+++ b/tests/server/core/worker.js
@@ -39,6 +39,10 @@ describe('Worker process running in production', function() {
 				port: PORT
 			},
 			log: require('../mocks/log'),
+			middleware: [
+				['foo', function() {}],
+				[function() {}]
+			],
 			env: {
 				name: 'production',
 				isProduction: isProduction,
@@ -129,6 +133,11 @@ describe('Worker process running in production', function() {
 
 	it('Should add a middleware to hook up the http proxy', function() {
 		assert.isTrue(connect().use.calledWith(processor().proxy));
+	});
+
+	it('Should mount all additional middleware found in the config', function() {
+		assert.isTrue(connect().use.calledWithExactly(config.middleware[0][0], config.middleware[0][1]));
+		assert.isTrue(connect().use.calledWithExactly(config.middleware[1][0]));
 	});
 
 	it('Should set up a ping end point', function() {
@@ -228,6 +237,7 @@ describe('Worker process running outside of production', function() {
 				'max-post-size': MAX_POST_SIZE,
 				port: PORT
 			},
+			middleware: [],
 			env: {
 				name: 'development',
 				isProduction: isProduction,


### PR DESCRIPTION
This allows an end-user to mount additional middleware before the core proxying behaviour of Shunter is mounted. This allows users to implement their own routes which expose information about Shunter.

See #81 for more information.